### PR TITLE
ci(workflows): bump 'setup-node' to v2 and use 'cache' option

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -10,10 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use node version 12
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
+        cache: npm
 
     - name: Configure Git, Run Tests, Update Baselines, Apply Fixes
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
       with:
         fetch-depth: 5
     - name: Use node version ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
     - name: Remove existing TypeScript
       run: |
         npm uninstall typescript --no-save

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -10,9 +10,10 @@ jobs:
 
     steps:
     - name: Use node version 12.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
+        cache: npm
     - uses: actions/checkout@v2
       with:
         fetch-depth: 5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,10 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use node version 12
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
+        cache: npm
     - name: Setup and publish nightly
       run: |
         npm whoami

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -12,9 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use node version 12
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12
+        cache: npm
     - name: Remove existing TypeScript
       run: |
         npm uninstall typescript --no-save

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -10,9 +10,10 @@ jobs:
 
     steps:
     - name: Use node version 12.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
+        cache: npm
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.client_payload.branch_name }}

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -15,9 +15,10 @@ jobs:
 
     steps:
     - name: Use node version 12.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
+        cache: npm
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.inputs.branch_name || github.event.client_payload.branch_name }}

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Use node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
+      with:
+        cache: npm
     - run: |
        npm init -y
        npm install --save typescript@next

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -10,10 +10,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use node version 12
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
+        cache: npm
 
     - name: Configure Git and Update LKG
       run: |

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -13,10 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
+        cache: npm
 
     - name: Configure git and update package-lock.json
       run: |


### PR DESCRIPTION
as per: [ci(workflows): bump 'setup-node' to v2 and use 'cache' option #44924](https://github.com/microsoft/TypeScript/pull/44924)


Based on an open commit that may change by @oscard0m: microsoft#44924